### PR TITLE
Refresh Token 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "i": "^0.3.7",
+        "jwt-decode": "^4.0.0",
         "modal": "^0.2.0",
         "prettier": "^3.4.2",
         "react": "^18.3.1",
@@ -4003,6 +4004,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "i": "^0.3.7",
+    "jwt-decode": "^4.0.0",
     "modal": "^0.2.0",
     "prettier": "^3.4.2",
     "react": "^18.3.1",

--- a/src/api/auth/authApi.tsx
+++ b/src/api/auth/authApi.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import axios from 'axios';
-import { authClient } from './client';
+import { authClient } from '../client';
 import {
   ReqSignUp,
   ResSignUp,

--- a/src/api/auth/authApi.tsx
+++ b/src/api/auth/authApi.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import axios from 'axios';
-import { authClient } from '../client';
+import { AuthClient } from '../client';
 import {
   ReqSignUp,
   ResSignUp,
@@ -11,7 +11,7 @@ import {
 
 export const login = async (data: Login): Promise<ResponseToken> => {
   try {
-    const response = await authClient.post<ResponseToken>('/auth/login', data);
+    const response = await AuthClient.post<ResponseToken>('/auth/login', data);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
@@ -30,7 +30,7 @@ export const login = async (data: Login): Promise<ResponseToken> => {
 
 export const signUp = async (data: ReqSignUp): Promise<ResSignUp> => {
   try {
-    const response = await authClient.post<ResSignUp>('/auth/signup', data);
+    const response = await AuthClient.post<ResSignUp>('/auth/signup', data);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
@@ -46,7 +46,7 @@ export const reissueToken = async (
   data: ReissueToken,
 ): Promise<ResponseToken> => {
   try {
-    const response = await authClient.post<ResponseToken>(
+    const response = await AuthClient.post<ResponseToken>(
       '/auth/reissue-token',
       data,
     );

--- a/src/api/auth/authClient.tsx
+++ b/src/api/auth/authClient.tsx
@@ -5,7 +5,7 @@ import { reissueToken } from './authApi';
 
 // axios 인터셉터를 사용하여 api 요청 시 토큰을 자동으로 갱신하는 기능
 export const authClient = axios.create({
-  baseURL: '/api', // 기본 API 엔드포인트
+  baseURL: import.meta.env.VITE_API_BASE_URL as string, // 기본 API 엔드포인트
   timeout: 5000, // 요청 타임아웃
 });
 

--- a/src/api/auth/authClient.tsx
+++ b/src/api/auth/authClient.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+
+function authClient() {
+  return <div></div>;
+}
+
+export default authClient;

--- a/src/api/auth/authClient.tsx
+++ b/src/api/auth/authClient.tsx
@@ -1,9 +1,57 @@
 import React from 'react';
 import axios from 'axios';
 import { jwtDecode } from 'jwt-decode';
+import { reissueToken } from './authApi';
 
-function authClient() {
-  return <div></div>;
-}
+// axios 인터셉터를 사용하여 api 요청 시 토큰을 자동으로 갱신하는 기능
+export const authClient = axios.create({
+  baseURL: '/api', // 기본 API 엔드포인트
+  timeout: 5000, // 요청 타임아웃
+});
 
-export default authClient;
+authClient.interceptors.request.use(
+  async (config) => {
+    // 토큰들을 sessionStorage에서 가져오기
+    const accessToken = sessionStorage.getItem('accessToken');
+    const refreshToken = sessionStorage.getItem('refreshToken');
+
+    if (accessToken && refreshToken) {
+      // exp는 JWT의 만료시간 (초 단위)를 나타냄
+      const decoded: { exp: number } = jwtDecode(accessToken);
+      // 밀리초 단위로 시간을 반환하는 Data.now()와 비교하기 위해 * 1000 을 해서 비교
+      const isTokenExpired = decoded.exp * 1000 < Date.now();
+
+      // isTokenExpired 이 True면 토큰이 만료된거고 False면 아직 유효함
+      if (isTokenExpired) {
+        try {
+          // 토큰 만료 시 refreshToken을 사용하여 새로운 accessToken을 발급
+          const { accessToken: newAccessToken } = await reissueToken({
+            userId: parseInt(sessionStorage.getItem('userId') || '0'),
+            refreshToken,
+          });
+          // 새로운 accessToken을 세션에 저장
+          sessionStorage.setItem('accessToken', newAccessToken);
+          // 서버에서 토큰 검증을 위해 헤더에 newAccessToken을 Bearer Token으로 보내어 검증
+          config.headers.Authorization = `Bearer ${newAccessToken}`;
+        } catch (error) {
+          // refreshToken 재발급 실패 시 로그아웃 처리 해버리기
+          sessionStorage.removeItem('accessToken');
+          sessionStorage.removeItem('refreshToken');
+          sessionStorage.removeItem('userId');
+
+          alert('세션이 만료되어 로그아웃 되었습니다.');
+
+          throw new Error('Session expired, please log in again');
+        }
+      } else {
+        // accessToken이 유효하다면 (만료 X) 그대로 사용하기
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);

--- a/src/api/board.tsx
+++ b/src/api/board.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Board } from '../models/Board';
 import { client } from './client';
+import { authClient } from './auth/authClient';
 
 // [GET]
 // async를 사용하여 Promise를 반환하는 비동기 함수 (Promise는 비동기 작업의 완료 or 실패를 나타내는 JS 객체)
@@ -58,7 +59,8 @@ export const getBoardById = async (id: number) => {
 export const createBoards = async (board: Board) => {
   try {
     // client에서 URL를 가져와서 /board를 붙여서 데이터를 보냄
-    const response = await client.post<Board>('/board', board, {
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.post<Board>('/board', board, {
       // 서버가 요청 데이터를 JSON 형식으로 인식하도록 명시, 문자 인코딩 방식 지정
       headers: {
         'Content-type': 'application/json; charset=UTF-8',
@@ -81,7 +83,8 @@ export const createBoards = async (board: Board) => {
 // PUT
 export const updateBoards = async (board: Board) => {
   try {
-    const response = await client.put<Board>(`/board/${board.id}`, board, {
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.put<Board>(`/board/${board.id}`, board, {
       headers: {
         'Content-type': 'application/json; charset=UTF-8',
       },
@@ -103,7 +106,8 @@ export const updateBoards = async (board: Board) => {
 
 export const deleteBoards = async (id: number) => {
   try {
-    const response = await client.delete(`/board/${id}`);
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.delete(`/board/${id}`);
     return response.data;
   } catch (error) {
     console.error('Failed to delete board:', error);

--- a/src/api/client.tsx
+++ b/src/api/client.tsx
@@ -11,9 +11,9 @@ client.defaults.baseURL = import.meta.env.VITE_API_BASE_URL as string;
 //효과 : 코드의 가독성 향상, 유지보수 간편
 
 // Auth 관련 api 가져오기
-const authClient = axios.create();
-authClient.defaults.baseURL = import.meta.env.VITE_API_BASE_URL as string;
-authClient.defaults.headers.common['Content-Type'] =
+const AuthClient = axios.create();
+AuthClient.defaults.baseURL = import.meta.env.VITE_API_BASE_URL as string;
+AuthClient.defaults.headers.common['Content-Type'] =
   'application/json; charset=UTF-8';
 
-export { client, authClient };
+export { client, AuthClient };

--- a/src/api/comment.tsx
+++ b/src/api/comment.tsx
@@ -1,8 +1,7 @@
 import { client } from './client';
-import { data } from 'react-router-dom';
 import axios from 'axios';
-import { Comment } from '../models/Comment';
-import { error } from 'console';
+import { Comment } from '~/models/Comment';
+import { authClient } from './auth/authClient';
 
 //get
 export const getCommentsByBoardId = async (boardId: number) => {
@@ -54,7 +53,8 @@ export const getCommentsCountByCategory = async (boardId: number) => {
 //post
 export const createComments = async (comment: Comment, boardId: number) => {
   try {
-    const response = await client.post<Comment>(
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.post<Comment>(
       `/comment/${boardId}`,
       comment,
       {
@@ -79,7 +79,8 @@ export const createChildComments = async (
   parentId: number,
 ) => {
   try {
-    const response = await client.post<Comment>(
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.post<Comment>(
       `/comment/${boardId}`,
       {
         userId: comment.userId,
@@ -104,7 +105,8 @@ export const createChildComments = async (
 //put
 export const updateComments = async (comment: Comment) => {
   try {
-    const response = await client.put<Comment>(
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.put<Comment>(
       `/comment/${comment.id}`,
       comment,
       {
@@ -125,7 +127,8 @@ export const updateComments = async (comment: Comment) => {
 //delete
 export const deleteComments = async (id: number) => {
   try {
-    const response = await client.delete<Comment>(`/comment/${id}`);
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.delete<Comment>(`/comment/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/api/project.tsx
+++ b/src/api/project.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Project } from '~/models/Project';
 import { client } from './client';
+import { authClient } from './auth/authClient';
 
 export const getProjects = async () => {
   try {
@@ -36,7 +37,8 @@ export const getProjectById = async (id: number) => {
 
 export const createProjects = async (project: Project) => {
   try {
-    const response = await client.post<Project>('/admin/project', project, {
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.post<Project>('/admin/project', project, {
       headers: {
         'Content-Type': 'application/json; charset=UTF-8',
       },
@@ -58,7 +60,8 @@ export const createProjects = async (project: Project) => {
 
 export const updateProject = async (project: Project) => {
   try {
-    const response = await client.put<Project>(
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.put<Project>(
       `/admin/project/${project.id}`,
       project,
       {
@@ -79,7 +82,8 @@ export const updateProject = async (project: Project) => {
 
 export const deleteProject = async (id: number) => {
   try {
-    const response = await client.delete(`/admin/project/${id}`);
+    // 권한이 필요한 작업에 authClient 사용
+    const response = await authClient.delete(`/admin/project/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/store/authStore.tsx
+++ b/src/store/authStore.tsx
@@ -12,7 +12,7 @@ import {
   login as loginApi,
   signUp as signUpApi,
   reissueToken as reissueTokenApi,
-} from '~/api/authApi';
+} from '~/api/auth/authApi';
 import { stringify } from 'querystring';
 
 // Zustand에서 관리할 상태의 구조, 데이터 Type 정의


### PR DESCRIPTION
- api 폴더안에 auth 폴더 만들어서 기능별로 구분
- JWT 디코딩을 위한 jwt-decode 라이브러리 추가
- refreshToken을 사용해서 accessToken  갱신되게 함
- client.tsx에 있는 authApi이름 변경 ( authApi -> AuthApi)
- 권한이 필요한 작업 메서드 authClient로 엔드포인트 수정 (ex. 생성, 수정, 삭제 같은 작업들)
- Bearer Token 방식을 활용하여 Header에 accessToken을 서버로 보내줌